### PR TITLE
fix(nav): distinct Hire Me icon and fix footer label wrap

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -13,6 +13,7 @@ import {
   Home,
   BookOpen,
   Briefcase,
+  Handshake,
 } from "lucide-react";
 
 import { WaveDivider } from "@components/WaveDivider";
@@ -31,7 +32,7 @@ export async function Footer() {
     { label: "Home", href: "/", icon: Home },
     { label: "Blog", href: "/posts", icon: BookOpen },
     { label: "Works", href: "/works", icon: Briefcase },
-    { label: "Hire Me", href: "/hire", icon: Mail },
+    { label: "Hire Me", href: "/hire", icon: Handshake },
   ];
 
   const socialLinks = [
@@ -106,7 +107,7 @@ export async function Footer() {
                   <li key={label} className="m-0 p-0">
                     <Link
                       href={href}
-                      className="group inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
+                      className="group inline-flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
                     >
                       <Icon className="w-3.5 h-3.5" />
                       {label}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 
-import { ChevronUp, Search, Home, BookOpen, Sparkles, Briefcase, Mail } from "lucide-react";
+import { ChevronUp, Search, Home, BookOpen, Sparkles, Briefcase, Handshake } from "lucide-react";
 import { useWindowScroll } from "@uidotdev/usehooks";
 
 import { ThemeToggle } from "@components/ThemeToggle";
@@ -90,10 +90,10 @@ export function Header() {
             className={`nav-pill ${pathname.startsWith("/hire") ? "nav-pill-active" : ""}`}
           >
             {isScrolled ? (
-              <Mail className="h-4 w-4" />
+              <Handshake className="h-4 w-4" />
             ) : (
               <span className="flex items-center gap-1.5">
-                <Mail className="h-3.5 w-3.5" />
+                <Handshake className="h-3.5 w-3.5" />
                 Hire Me
               </span>
             )}


### PR DESCRIPTION
## Summary
- "Hire Me" and "Contact" shared the same `Mail` icon. Hire Me now uses a `Handshake` icon in both the header and footer so the two are visually distinct.
- "Hire Me" was wrapping onto two lines in the footer on mobile — added `whitespace-nowrap` to the footer nav links to keep each label on one line.

## Notes
- `Mail` import is retained in the footer (still used by the Contact link and the brand `mailto:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)